### PR TITLE
Change the order of submit buttons

### DIFF
--- a/exercise/08-errors/app/routes/posts/admin/$slug.tsx
+++ b/exercise/08-errors/app/routes/posts/admin/$slug.tsx
@@ -128,7 +128,17 @@ export default function PostAdmin() {
           defaultValue={data?.post?.markdown}
         />
       </p>
-      <div className="flex justify-end gap-4">
+      <div className="flex flex-row-reverse gap-4">
+        <button
+          type="submit"
+          name="intent"
+          value={isNewPost ? "create" : "update"}
+          className="rounded bg-blue-500 py-2 px-4 text-white hover:bg-blue-600 focus:bg-blue-400 disabled:bg-blue-300"
+          disabled={isCreating || isUpdating}
+        >
+          {isNewPost ? (isCreating ? "Creating..." : "Create") : null}
+          {isNewPost ? null : isUpdating ? "Updating..." : "Update"}
+        </button>
         {isNewPost ? null : (
           <button
             type="submit"
@@ -140,16 +150,6 @@ export default function PostAdmin() {
             {isDeleting ? "Deleting..." : "Delete"}
           </button>
         )}
-        <button
-          type="submit"
-          name="intent"
-          value={isNewPost ? "create" : "update"}
-          className="rounded bg-blue-500 py-2 px-4 text-white hover:bg-blue-600 focus:bg-blue-400 disabled:bg-blue-300"
-          disabled={isCreating || isUpdating}
-        >
-          {isNewPost ? (isCreating ? "Creating..." : "Create") : null}
-          {isNewPost ? null : isUpdating ? "Updating..." : "Update"}
-        </button>
       </div>
     </Form>
   );

--- a/exercise/09-env-vars/app/routes/posts/admin/$slug.tsx
+++ b/exercise/09-env-vars/app/routes/posts/admin/$slug.tsx
@@ -133,7 +133,17 @@ export default function PostAdmin() {
           defaultValue={data?.post?.markdown}
         />
       </p>
-      <div className="flex justify-end gap-4">
+      <div className="flex flex-row-reverse gap-4">
+        <button
+          type="submit"
+          name="intent"
+          value={isNewPost ? "create" : "update"}
+          className="rounded bg-blue-500 py-2 px-4 text-white hover:bg-blue-600 focus:bg-blue-400 disabled:bg-blue-300"
+          disabled={isCreating || isUpdating}
+        >
+          {isNewPost ? (isCreating ? "Creating..." : "Create") : null}
+          {isNewPost ? null : isUpdating ? "Updating..." : "Update"}
+        </button>
         {isNewPost ? null : (
           <button
             type="submit"
@@ -145,16 +155,6 @@ export default function PostAdmin() {
             {isDeleting ? "Deleting..." : "Delete"}
           </button>
         )}
-        <button
-          type="submit"
-          name="intent"
-          value={isNewPost ? "create" : "update"}
-          className="rounded bg-blue-500 py-2 px-4 text-white hover:bg-blue-600 focus:bg-blue-400 disabled:bg-blue-300"
-          disabled={isCreating || isUpdating}
-        >
-          {isNewPost ? (isCreating ? "Creating..." : "Create") : null}
-          {isNewPost ? null : isUpdating ? "Updating..." : "Update"}
-        </button>
       </div>
     </Form>
   );

--- a/exercise/10-admin-user/app/routes/posts/admin/$slug.tsx
+++ b/exercise/10-admin-user/app/routes/posts/admin/$slug.tsx
@@ -136,7 +136,17 @@ export default function PostAdmin() {
           defaultValue={data?.post?.markdown}
         />
       </p>
-      <div className="flex justify-end gap-4">
+      <div className="flex flex-row-reverse gap-4">
+        <button
+          type="submit"
+          name="intent"
+          value={isNewPost ? "create" : "update"}
+          className="rounded bg-blue-500 py-2 px-4 text-white hover:bg-blue-600 focus:bg-blue-400 disabled:bg-blue-300"
+          disabled={isCreating || isUpdating}
+        >
+          {isNewPost ? (isCreating ? "Creating..." : "Create") : null}
+          {isNewPost ? null : isUpdating ? "Updating..." : "Update"}
+        </button>
         {isNewPost ? null : (
           <button
             type="submit"
@@ -148,16 +158,6 @@ export default function PostAdmin() {
             {isDeleting ? "Deleting..." : "Delete"}
           </button>
         )}
-        <button
-          type="submit"
-          name="intent"
-          value={isNewPost ? "create" : "update"}
-          className="rounded bg-blue-500 py-2 px-4 text-white hover:bg-blue-600 focus:bg-blue-400 disabled:bg-blue-300"
-          disabled={isCreating || isUpdating}
-        >
-          {isNewPost ? (isCreating ? "Creating..." : "Create") : null}
-          {isNewPost ? null : isUpdating ? "Updating..." : "Update"}
-        </button>
       </div>
     </Form>
   );

--- a/final/07-multiple-forms/app/routes/posts/admin/$slug.tsx
+++ b/final/07-multiple-forms/app/routes/posts/admin/$slug.tsx
@@ -128,7 +128,17 @@ export default function PostAdmin() {
           defaultValue={data?.post?.markdown}
         />
       </p>
-      <div className="flex justify-end gap-4">
+      <div className="flex flex-row-reverse gap-4">
+        <button
+          type="submit"
+          name="intent"
+          value={isNewPost ? "create" : "update"}
+          className="rounded bg-blue-500 py-2 px-4 text-white hover:bg-blue-600 focus:bg-blue-400 disabled:bg-blue-300"
+          disabled={isCreating || isUpdating}
+        >
+          {isNewPost ? (isCreating ? "Creating..." : "Create") : null}
+          {isNewPost ? null : isUpdating ? "Updating..." : "Update"}
+        </button>
         {isNewPost ? null : (
           <button
             type="submit"
@@ -140,16 +150,6 @@ export default function PostAdmin() {
             {isDeleting ? "Deleting..." : "Delete"}
           </button>
         )}
-        <button
-          type="submit"
-          name="intent"
-          value={isNewPost ? "create" : "update"}
-          className="rounded bg-blue-500 py-2 px-4 text-white hover:bg-blue-600 focus:bg-blue-400 disabled:bg-blue-300"
-          disabled={isCreating || isUpdating}
-        >
-          {isNewPost ? (isCreating ? "Creating..." : "Create") : null}
-          {isNewPost ? null : isUpdating ? "Updating..." : "Update"}
-        </button>
       </div>
     </Form>
   );

--- a/final/08-errors.extra-01-catch-boundaries/app/routes/posts/admin/$slug.tsx
+++ b/final/08-errors.extra-01-catch-boundaries/app/routes/posts/admin/$slug.tsx
@@ -133,7 +133,17 @@ export default function PostAdmin() {
           defaultValue={data?.post?.markdown}
         />
       </p>
-      <div className="flex justify-end gap-4">
+      <div className="flex flex-row-reverse gap-4">
+        <button
+          type="submit"
+          name="intent"
+          value={isNewPost ? "create" : "update"}
+          className="rounded bg-blue-500 py-2 px-4 text-white hover:bg-blue-600 focus:bg-blue-400 disabled:bg-blue-300"
+          disabled={isCreating || isUpdating}
+        >
+          {isNewPost ? (isCreating ? "Creating..." : "Create") : null}
+          {isNewPost ? null : isUpdating ? "Updating..." : "Update"}
+        </button>
         {isNewPost ? null : (
           <button
             type="submit"
@@ -145,16 +155,6 @@ export default function PostAdmin() {
             {isDeleting ? "Deleting..." : "Delete"}
           </button>
         )}
-        <button
-          type="submit"
-          name="intent"
-          value={isNewPost ? "create" : "update"}
-          className="rounded bg-blue-500 py-2 px-4 text-white hover:bg-blue-600 focus:bg-blue-400 disabled:bg-blue-300"
-          disabled={isCreating || isUpdating}
-        >
-          {isNewPost ? (isCreating ? "Creating..." : "Create") : null}
-          {isNewPost ? null : isUpdating ? "Updating..." : "Update"}
-        </button>
       </div>
     </Form>
   );

--- a/final/08-errors/app/routes/posts/admin/$slug.tsx
+++ b/final/08-errors/app/routes/posts/admin/$slug.tsx
@@ -129,7 +129,17 @@ export default function PostAdmin() {
           defaultValue={data?.post?.markdown}
         />
       </p>
-      <div className="flex justify-end gap-4">
+      <div className="flex flex-row-reverse gap-4">
+        <button
+          type="submit"
+          name="intent"
+          value={isNewPost ? "create" : "update"}
+          className="rounded bg-blue-500 py-2 px-4 text-white hover:bg-blue-600 focus:bg-blue-400 disabled:bg-blue-300"
+          disabled={isCreating || isUpdating}
+        >
+          {isNewPost ? (isCreating ? "Creating..." : "Create") : null}
+          {isNewPost ? null : isUpdating ? "Updating..." : "Update"}
+        </button>
         {isNewPost ? null : (
           <button
             type="submit"
@@ -141,16 +151,6 @@ export default function PostAdmin() {
             {isDeleting ? "Deleting..." : "Delete"}
           </button>
         )}
-        <button
-          type="submit"
-          name="intent"
-          value={isNewPost ? "create" : "update"}
-          className="rounded bg-blue-500 py-2 px-4 text-white hover:bg-blue-600 focus:bg-blue-400 disabled:bg-blue-300"
-          disabled={isCreating || isUpdating}
-        >
-          {isNewPost ? (isCreating ? "Creating..." : "Create") : null}
-          {isNewPost ? null : isUpdating ? "Updating..." : "Update"}
-        </button>
       </div>
     </Form>
   );

--- a/final/09-env-vars.extra-01-ts/app/routes/posts/admin/$slug.tsx
+++ b/final/09-env-vars.extra-01-ts/app/routes/posts/admin/$slug.tsx
@@ -133,7 +133,17 @@ export default function PostAdmin() {
           defaultValue={data?.post?.markdown}
         />
       </p>
-      <div className="flex justify-end gap-4">
+      <div className="flex flex-row-reverse gap-4">
+        <button
+          type="submit"
+          name="intent"
+          value={isNewPost ? "create" : "update"}
+          className="rounded bg-blue-500 py-2 px-4 text-white hover:bg-blue-600 focus:bg-blue-400 disabled:bg-blue-300"
+          disabled={isCreating || isUpdating}
+        >
+          {isNewPost ? (isCreating ? "Creating..." : "Create") : null}
+          {isNewPost ? null : isUpdating ? "Updating..." : "Update"}
+        </button>
         {isNewPost ? null : (
           <button
             type="submit"
@@ -145,16 +155,6 @@ export default function PostAdmin() {
             {isDeleting ? "Deleting..." : "Delete"}
           </button>
         )}
-        <button
-          type="submit"
-          name="intent"
-          value={isNewPost ? "create" : "update"}
-          className="rounded bg-blue-500 py-2 px-4 text-white hover:bg-blue-600 focus:bg-blue-400 disabled:bg-blue-300"
-          disabled={isCreating || isUpdating}
-        >
-          {isNewPost ? (isCreating ? "Creating..." : "Create") : null}
-          {isNewPost ? null : isUpdating ? "Updating..." : "Update"}
-        </button>
       </div>
     </Form>
   );

--- a/final/09-env-vars/app/routes/posts/admin/$slug.tsx
+++ b/final/09-env-vars/app/routes/posts/admin/$slug.tsx
@@ -133,7 +133,17 @@ export default function PostAdmin() {
           defaultValue={data?.post?.markdown}
         />
       </p>
-      <div className="flex justify-end gap-4">
+      <div className="flex flex-row-reverse gap-4">
+        <button
+          type="submit"
+          name="intent"
+          value={isNewPost ? "create" : "update"}
+          className="rounded bg-blue-500 py-2 px-4 text-white hover:bg-blue-600 focus:bg-blue-400 disabled:bg-blue-300"
+          disabled={isCreating || isUpdating}
+        >
+          {isNewPost ? (isCreating ? "Creating..." : "Create") : null}
+          {isNewPost ? null : isUpdating ? "Updating..." : "Update"}
+        </button>
         {isNewPost ? null : (
           <button
             type="submit"
@@ -145,16 +155,6 @@ export default function PostAdmin() {
             {isDeleting ? "Deleting..." : "Delete"}
           </button>
         )}
-        <button
-          type="submit"
-          name="intent"
-          value={isNewPost ? "create" : "update"}
-          className="rounded bg-blue-500 py-2 px-4 text-white hover:bg-blue-600 focus:bg-blue-400 disabled:bg-blue-300"
-          disabled={isCreating || isUpdating}
-        >
-          {isNewPost ? (isCreating ? "Creating..." : "Create") : null}
-          {isNewPost ? null : isUpdating ? "Updating..." : "Update"}
-        </button>
       </div>
     </Form>
   );

--- a/final/10-admin-user.extra-01-ui/app/routes/posts/admin/$slug.tsx
+++ b/final/10-admin-user.extra-01-ui/app/routes/posts/admin/$slug.tsx
@@ -136,7 +136,17 @@ export default function PostAdmin() {
           defaultValue={data?.post?.markdown}
         />
       </p>
-      <div className="flex justify-end gap-4">
+      <div className="flex flex-row-reverse gap-4">
+        <button
+          type="submit"
+          name="intent"
+          value={isNewPost ? "create" : "update"}
+          className="rounded bg-blue-500 py-2 px-4 text-white hover:bg-blue-600 focus:bg-blue-400 disabled:bg-blue-300"
+          disabled={isCreating || isUpdating}
+        >
+          {isNewPost ? (isCreating ? "Creating..." : "Create") : null}
+          {isNewPost ? null : isUpdating ? "Updating..." : "Update"}
+        </button>
         {isNewPost ? null : (
           <button
             type="submit"
@@ -148,16 +158,6 @@ export default function PostAdmin() {
             {isDeleting ? "Deleting..." : "Delete"}
           </button>
         )}
-        <button
-          type="submit"
-          name="intent"
-          value={isNewPost ? "create" : "update"}
-          className="rounded bg-blue-500 py-2 px-4 text-white hover:bg-blue-600 focus:bg-blue-400 disabled:bg-blue-300"
-          disabled={isCreating || isUpdating}
-        >
-          {isNewPost ? (isCreating ? "Creating..." : "Create") : null}
-          {isNewPost ? null : isUpdating ? "Updating..." : "Update"}
-        </button>
       </div>
     </Form>
   );

--- a/final/10-admin-user/app/routes/posts/admin/$slug.tsx
+++ b/final/10-admin-user/app/routes/posts/admin/$slug.tsx
@@ -136,7 +136,17 @@ export default function PostAdmin() {
           defaultValue={data?.post?.markdown}
         />
       </p>
-      <div className="flex justify-end gap-4">
+      <div className="flex flex-row-reverse gap-4">
+        <button
+          type="submit"
+          name="intent"
+          value={isNewPost ? "create" : "update"}
+          className="rounded bg-blue-500 py-2 px-4 text-white hover:bg-blue-600 focus:bg-blue-400 disabled:bg-blue-300"
+          disabled={isCreating || isUpdating}
+        >
+          {isNewPost ? (isCreating ? "Creating..." : "Create") : null}
+          {isNewPost ? null : isUpdating ? "Updating..." : "Update"}
+        </button>
         {isNewPost ? null : (
           <button
             type="submit"
@@ -148,16 +158,6 @@ export default function PostAdmin() {
             {isDeleting ? "Deleting..." : "Delete"}
           </button>
         )}
-        <button
-          type="submit"
-          name="intent"
-          value={isNewPost ? "create" : "update"}
-          className="rounded bg-blue-500 py-2 px-4 text-white hover:bg-blue-600 focus:bg-blue-400 disabled:bg-blue-300"
-          disabled={isCreating || isUpdating}
-        >
-          {isNewPost ? (isCreating ? "Creating..." : "Create") : null}
-          {isNewPost ? null : isUpdating ? "Updating..." : "Update"}
-        </button>
       </div>
     </Form>
   );


### PR DESCRIPTION
I would change the order of the Delete and Create/Update buttons and apply styles to reverse the order in the browser. If you submit the form with Enter the first submit button will be used as default submit and currently it will delete the post.

I think this could have also been addressed in the course that when using multiple submit buttons the first one is used as default.